### PR TITLE
Add regex to filter events

### DIFF
--- a/custom_components/isc/const.py
+++ b/custom_components/isc/const.py
@@ -30,6 +30,7 @@ CONF_TIMEFORMAT = "timeformat"
 CONF_LOOKAHEAD = "lookahead"
 CONF_SW = "startswith"
 CONF_CONTAINS = "contains"
+CONF_REGEX = "regex"
 CONF_SHOW_BLANK = "show_blank"
 CONF_FORCE_UPDATE = "force_update"
 CONF_SHOW_REMAINING = "show_remaining"
@@ -44,6 +45,7 @@ DEFAULT_NAME = "ics_sensor"
 DEFAULT_ID = 1
 DEFAULT_SW = ""
 DEFAULT_CONTAINS = ""
+DEFAULT_REGEX = ".*"
 DEFAULT_TIMEFORMAT = "%A, %d.%m.%Y"
 DEFAULT_LOOKAHEAD = 365
 DEFAULT_SHOW_BLANK = ""
@@ -71,6 +73,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 	vol.Optional(CONF_TIMEFORMAT, default=DEFAULT_TIMEFORMAT): cv.string,
 	vol.Optional(CONF_SW, default=DEFAULT_SW): cv.string,
 	vol.Optional(CONF_CONTAINS, default=DEFAULT_CONTAINS): cv.string,
+	vol.Optional(CONF_REGEX, default=DEFAULT_REGEX): cv.string,
 	vol.Optional(CONF_LOOKAHEAD, default=DEFAULT_LOOKAHEAD): vol.Coerce(int),
 	vol.Optional(CONF_SHOW_BLANK, default=DEFAULT_SHOW_BLANK): cv.string,
 	vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): vol.Coerce(int),
@@ -101,6 +104,7 @@ def ensure_config(user_input, hass):
 	out[CONF_TIMEFORMAT] = DEFAULT_TIMEFORMAT
 	out[CONF_SW] = DEFAULT_SW
 	out[CONF_CONTAINS] = DEFAULT_CONTAINS
+	out[CONF_REGEX] = DEFAULT_REGEX
 	out[CONF_LOOKAHEAD] = DEFAULT_LOOKAHEAD
 	out[CONF_SHOW_BLANK] = DEFAULT_SHOW_BLANK
 	out[CONF_FORCE_UPDATE] = DEFAULT_FORCE_UPDATE
@@ -129,6 +133,10 @@ def ensure_config(user_input, hass):
 			out[CONF_CONTAINS] = user_input[CONF_CONTAINS]
 			if(out[CONF_CONTAINS] == " "):
 				out[CONF_CONTAINS] = ""
+		if CONF_REGEX in user_input:
+			out[CONF_REGEX] = user_input[CONF_REGEX]
+			if(out[CONF_REGEX] == " "):
+				out[CONF_REGEX] = ""
 		if CONF_LOOKAHEAD in user_input:
 			out[CONF_LOOKAHEAD] = user_input[CONF_LOOKAHEAD]
 		if CONF_SHOW_REMAINING in user_input:
@@ -217,6 +225,7 @@ def create_form(page, user_input, hass):
 		data_schema[vol.Optional(CONF_TIMEFORMAT, default=user_input[CONF_TIMEFORMAT])] = str
 		data_schema[vol.Optional(CONF_SW, default=user_input[CONF_SW])] = str
 		data_schema[vol.Optional(CONF_CONTAINS, default=user_input[CONF_CONTAINS])] = str
+		data_schema[vol.Optional(CONF_REGEX, default=user_input[CONF_REGEX])] = str
 		data_schema[vol.Optional(CONF_LOOKAHEAD, default=user_input[CONF_LOOKAHEAD])] = int
 		data_schema[vol.Optional(CONF_ICON, default=user_input[CONF_ICON])] = str
 

--- a/custom_components/isc/translations/en.json
+++ b/custom_components/isc/translations/en.json
@@ -12,6 +12,7 @@
                     "timeformat": "Timeformat (see http://strftime.org/).",
                     "startswith": "Startswith Filter, see link above for more info" ,
                     "contains": "Contains Filter, see link above for more info" ,
+                    "regex": "Regex Filter, see link above for more info" ,
                     "lookahead": "Lookahead",
                     "icon": "Icon  (see https://materialdesignicons.com/)."
                 }
@@ -52,6 +53,7 @@
                     "timeformat": "Timeformat (see http://strftime.org/).",
                     "startswith": "Startswith Filter, see link above for more info" ,
                     "contains": "Contains Filter, see link above for more info" ,
+                    "regex": "Regex Filter, see link above for more info" ,
                     "lookahead": "Lookahead",
                     "icon": "Icon  (see https://materialdesignicons.com/)."
                 }


### PR DESCRIPTION
This will add regex to filter events.
I need this as I have to filter for `Papier` on a calendar which contains `Papier` and `Papier 4 Rad`. So `starts_with` would not work here.