### PR TITLE
Migrate to async_forward_entry_setups

### DIFF
--- a/custom_components/isc/__init__.py
+++ b/custom_components/isc/__init__.py
@@ -22,7 +22,7 @@ async def async_setup_entry(hass, config_entry):
 	)
 	config_entry.add_update_listener(update_listener)
 	# Add sensor
-	await hass.config_entries.async_forward_entry_setup(config_entry, PLATFORM)
+	await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 	return True
 
 

--- a/custom_components/isc/const.py
+++ b/custom_components/isc/const.py
@@ -18,6 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 # generals
 DOMAIN = "ics"
 PLATFORM = "sensor"
+PLATFORMS = ["sensor"]
 VERSION = "1.2.0"
 ISSUE_URL = "https://github.com/koljawindeler/ics/issues"
 


### PR DESCRIPTION
Moving to async_forward_entry_setups from async_forward_entry_setup due to future deprecation in 2025.6